### PR TITLE
Create a release in Sentry for each Heroku deployment

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,3 +52,4 @@ write_profile_d_script
 write_export
 
 post_compile_hook
+create_sentry_release

--- a/bin/compile
+++ b/bin/compile
@@ -50,6 +50,6 @@ backup_app
 backup_mix
 write_profile_d_script
 write_export
+create_sentry_release
 
 post_compile_hook
-create_sentry_release

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,5 +1,5 @@
 erlang_version=18.3
 elixir_version=1.2.6
 always_rebuild=false
-config_vars_to_export=(DATABASE_URL)
+config_vars_to_export=(DATABASE_URL SOURCE_URL SENTRY_API_KEY SENTRY_ORG SENTRY_PROJECT)
 runtime_path=/app

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -121,5 +121,7 @@ function create_sentry_release() {
   if [ -n "$SENTRY_API_KEY" ]; then
     output_section "Creating Sentry release for source-version ${SOURCE_VERSION}"
     curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${SENTRY_API_KEY}" -H "Cache-Control: no-cache" -d "{ \"version\": \"${SOURCE_VERSION}\", \"ref\": \"${SOURCE_VERSION}\", \"url\": \"${SOURCE_URL}\"}" "https://sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/releases/"  || exit 1
+  else
+    output_section "Skipping Sentry release tagging"
   fi
 }

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -116,3 +116,10 @@ function write_export() {
 
   echo $export_line > $build_pack_path/export
 }
+
+function create_sentry_release() {
+  if [ -n "$SENTRY_API_KEY" ]; then
+    output_section "Creating Sentry release for source-version ${SOURCE_VERSION}"
+    curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${SENTRY_API_KEY}" -H "Cache-Control: no-cache" -d "{ \"version\": \"${SOURCE_VERSION}\", \"ref\": \"${SOURCE_VERSION}\", \"url\": \"${SOURCE_URL}\"}" "https://sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}/releases/"  || exit 1
+  fi
+}


### PR DESCRIPTION
Requires the following environment variables be set in order to create a release on Sentry:
- `SOURCE_URL` - URL to the source code (e.g. Github)
- `SENTRY_API_KEY` - API key to authenticate with Sentry
- `SENTRY_ORG` - Sentry organization slug
- `SENTRY_PROJECT` - Sentry project slug
